### PR TITLE
Add trench assist poses and logic, needs debugging

### DIFF
--- a/shared/src/main/java/com/team581/util/FieldUtil.java
+++ b/shared/src/main/java/com/team581/util/FieldUtil.java
@@ -36,7 +36,7 @@ public class FieldUtil {
   public static final double BLUE_BOX_COORDINATE_X =
       BLUE_TRENCH_X - TRENCH_TO_ROBOT_STARTING_LINE_DISTANCE_X;
 
-  public static final double TRENCH_LENGTH_Y = Units.inchesToMeters(25.62 * 2);
+  private static final double TRENCH_LENGTH_Y = Units.inchesToMeters(49.84);
   public static final double OPPOSITE_TRENCH_COORDINATE_Y = FIELD_WIDTH - TRENCH_LENGTH_Y;
   // end of calculations
   public static final Rectangle2d RED_LEFT_UNSAFE_TRENCH_BOX =
@@ -72,16 +72,33 @@ public class FieldUtil {
           RED_LEFT_UNSAFE_TRENCH_BOX,
           RED_RIGHT_UNSAFE_TRENCH_BOX);
 
-  // TODO: Fill out trench assist zones
-  // Custom zones to enable trench assist
+  // Custom zones to enable trench assist for driver to cleanly drive through with speed
+  public static final double BOTTOM_TRENCH_Y = Units.inchesToMeters(TRENCH_LENGTH_Y / 2.0);
+  public static final double TOP_TRENCH_Y = Units.inchesToMeters(FIELD_WIDTH - TRENCH_LENGTH_Y / 2.0);
+  private static final double TRENCH_ASSIST_ZONE_LENGTH_X = Units.inchesToMeters(70.0);
+  private static final double TRENCH_ASSIST_ZONE_LENGTH_Y = Units.inchesToMeters(75.0);
   private static final Rectangle2d RED_LEFT_TRENCH_ASSIST_ZONE =
-      new Rectangle2d(new Translation2d(), new Translation2d());
+      new Rectangle2d(
+          new Translation2d(RED_TRENCH_X - TRENCH_ASSIST_ZONE_LENGTH_X / 2.0, 0.0),
+          new Translation2d(
+              RED_TRENCH_X + TRENCH_ASSIST_ZONE_LENGTH_X / 2.0, TRENCH_ASSIST_ZONE_LENGTH_Y));
   private static final Rectangle2d RED_RIGHT_TRENCH_ASSIST_ZONE =
-      new Rectangle2d(new Translation2d(), new Translation2d());
+      new Rectangle2d(
+          new Translation2d(
+              RED_TRENCH_X - TRENCH_ASSIST_ZONE_LENGTH_X / 2.0,
+              FIELD_WIDTH - TRENCH_ASSIST_ZONE_LENGTH_Y),
+          new Translation2d(RED_TRENCH_X + TRENCH_ASSIST_ZONE_LENGTH_X / 2.0, FIELD_WIDTH));
   private static final Rectangle2d BLUE_LEFT_TRENCH_ASSIST_ZONE =
-      new Rectangle2d(new Translation2d(), new Translation2d());
+      new Rectangle2d(
+          new Translation2d(
+              BLUE_TRENCH_X - TRENCH_ASSIST_ZONE_LENGTH_X / 2.0,
+              FIELD_WIDTH - TRENCH_ASSIST_ZONE_LENGTH_Y),
+          new Translation2d(BLUE_TRENCH_X + TRENCH_ASSIST_ZONE_LENGTH_X / 2.0, FIELD_WIDTH));
   private static final Rectangle2d BLUE_RIGHT_TRENCH_ASSIST_ZONE =
-      new Rectangle2d(new Translation2d(), new Translation2d());
+      new Rectangle2d(
+          new Translation2d(BLUE_TRENCH_X - TRENCH_ASSIST_ZONE_LENGTH_X / 2.0, 0.0),
+          new Translation2d(
+              BLUE_TRENCH_X + TRENCH_ASSIST_ZONE_LENGTH_X / 2.0, TRENCH_ASSIST_ZONE_LENGTH_Y));
 
   public static final List<Rectangle2d> TRENCH_ASSIST_ZONES =
       ImmutableList.of(
@@ -90,13 +107,13 @@ public class FieldUtil {
           BLUE_LEFT_TRENCH_ASSIST_ZONE,
           BLUE_RIGHT_TRENCH_ASSIST_ZONE);
 
-  public static Rectangle2d getAllianceZone() {
-    return FmsUtil.isRedAlliance() ? RED_ALLIANCE_ZONE : BLUE_ALLIANCE_ZONE;
-  }
-
   /** Returns the trench assist zone that the robot is currently in, if it exists. */
   public static Optional<Rectangle2d> getCurrentTrenchAssistZone(Translation2d robotPose) {
     return TRENCH_ASSIST_ZONES.stream().filter(zone -> zone.contains(robotPose)).findFirst();
+  }
+
+  public static Rectangle2d getAllianceZone() {
+    return FmsUtil.isRedAlliance() ? RED_ALLIANCE_ZONE : BLUE_ALLIANCE_ZONE;
   }
 
   public static Translation2d getFeed1Pose() {

--- a/shared/src/main/java/com/team581/util/FieldUtil.java
+++ b/shared/src/main/java/com/team581/util/FieldUtil.java
@@ -87,7 +87,8 @@ public class FieldUtil {
 
   // Custom zones to enable trench assist for driver to cleanly drive through with speed
   public static final double BOTTOM_TRENCH_Y = Units.inchesToMeters(TRENCH_LENGTH_Y / 2.0);
-  public static final double TOP_TRENCH_Y = Units.inchesToMeters(FIELD_WIDTH - TRENCH_LENGTH_Y / 2.0);
+  public static final double TOP_TRENCH_Y =
+      Units.inchesToMeters(FIELD_WIDTH - TRENCH_LENGTH_Y / 2.0);
   private static final double TRENCH_ASSIST_ZONE_LENGTH_X = Units.inchesToMeters(70.0);
   private static final double TRENCH_ASSIST_ZONE_LENGTH_Y = Units.inchesToMeters(75.0);
   private static final Rectangle2d RED_LEFT_TRENCH_ASSIST_ZONE =
@@ -120,13 +121,13 @@ public class FieldUtil {
           BLUE_LEFT_TRENCH_ASSIST_ZONE,
           BLUE_RIGHT_TRENCH_ASSIST_ZONE);
 
+  public static Rectangle2d getAllianceZone() {
+    return FmsUtil.isRedAlliance() ? RED_ALLIANCE_ZONE : BLUE_ALLIANCE_ZONE;
+  }
+
   /** Returns the trench assist zone that the robot is currently in, if it exists. */
   public static Optional<Rectangle2d> getCurrentTrenchAssistZone(Translation2d robotPose) {
     return TRENCH_ASSIST_ZONES.stream().filter(zone -> zone.contains(robotPose)).findFirst();
-  }
-
-  public static Rectangle2d getAllianceZone() {
-    return FmsUtil.isRedAlliance() ? RED_ALLIANCE_ZONE : BLUE_ALLIANCE_ZONE;
   }
 
   public static Translation2d getFeed1Pose() {

--- a/turret-bot/src/main/java/frc/robot/config/FeatureFlags.java
+++ b/turret-bot/src/main/java/frc/robot/config/FeatureFlags.java
@@ -13,8 +13,7 @@ public class FeatureFlags {
       FeatureFlag.of("TurretAngleComp", true);
   public static final BooleanSupplier VISION_HUB_TAGS_FILTER =
       FeatureFlag.of("OnlyUseHubTags", true);
-  public static final BooleanSupplier TRENCH_ASSIST =
-      FeatureFlag.of("TrenchAssist", false);
+  public static final BooleanSupplier TRENCH_ASSIST = FeatureFlag.of("TrenchAssist", false);
 
   private FeatureFlags() {}
 }

--- a/turret-bot/src/main/java/frc/robot/config/FeatureFlags.java
+++ b/turret-bot/src/main/java/frc/robot/config/FeatureFlags.java
@@ -13,6 +13,8 @@ public class FeatureFlags {
       FeatureFlag.of("TurretAngleComp", true);
   public static final BooleanSupplier VISION_HUB_TAGS_FILTER =
       FeatureFlag.of("OnlyUseHubTags", true);
+  public static final BooleanSupplier TRENCH_ASSIST =
+      FeatureFlag.of("TrenchAssist", false);
 
   private FeatureFlags() {}
 }

--- a/turret-bot/src/main/java/frc/robot/swerve/Swerve.java
+++ b/turret-bot/src/main/java/frc/robot/swerve/Swerve.java
@@ -157,7 +157,8 @@ public class Swerve extends StateMachineSubsystem<SwerveState> {
           if (ableToTrenchAssist()) {
             var robotPose = drivetrain.getState().Pose;
             var trenchAssistVelocity = getTrenchAssistVelocity(robotPose.getY());
-            if (MathUtil.isNear(teleopRequest.RotationalRate, 0, teleopRequest.RotationalDeadband)) {
+            if (MathUtil.isNear(
+                teleopRequest.RotationalRate, 0, teleopRequest.RotationalDeadband)) {
               var snapAngle = Math.round(robotPose.getRotation().getDegrees() / 90.0) * 90.0;
 
               drivetrain.setControl(

--- a/turret-bot/src/main/java/frc/robot/swerve/Swerve.java
+++ b/turret-bot/src/main/java/frc/robot/swerve/Swerve.java
@@ -27,13 +27,14 @@ import edu.wpi.first.networktables.DoubleSubscriber;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Notifier;
 import edu.wpi.first.wpilibj.RobotController;
+import frc.robot.config.FeatureFlags;
 import frc.robot.generated.TunerConstants.TunerSwerveDrivetrain;
 import frc.robot.util.scheduling.SubsystemPriority;
 import org.jspecify.annotations.Nullable;
 
 public class Swerve extends StateMachineSubsystem<SwerveState> {
-  private final DoubleSubscriber TRENCH_ASSIST_VELOCITY_THRESHOLD = DogLog.tunable("Swerve", 0.0);
-  private final DoubleSubscriber TRENCH_ASSIST_ANGLE_THRESHOLD = DogLog.tunable("Swerve", 0.0);
+  private final DoubleSubscriber TRENCH_ASSIST_VELOCITY_THRESHOLD = DogLog.tunable("Swerve", 4.0);
+  private final DoubleSubscriber TRENCH_ASSIST_ANGLE_THRESHOLD = DogLog.tunable("Swerve", 40.0);
 
   public static final double MAX_SPEED = 4.75;
 
@@ -151,26 +152,33 @@ public class Swerve extends StateMachineSubsystem<SwerveState> {
 
   private void sendSwerveRequest() {
     switch (getState()) {
-      case TELEOP -> drivetrain.setControl(teleopRequest);
+      case TELEOP -> {
+        if (FeatureFlags.TRENCH_ASSIST.getAsBoolean()) {
+          if (ableToTrenchAssist()) {
+            var robotPose = drivetrain.getState().Pose;
+            var trenchAssistVelocity = getTrenchAssistVelocity(robotPose.getY());
+            if (MathUtil.isNear(teleopRequest.RotationalRate, 0, teleopRequest.RotationalDeadband)) {
+              var snapAngle = Math.round(robotPose.getRotation().getDegrees() / 90.0) * 90.0;
+
+              drivetrain.setControl(
+                  teleopSnapsRequest
+                      .withVelocityY(trenchAssistVelocity)
+                      .withTargetDirection(Rotation2d.fromDegrees(snapAngle)));
+            } else {
+              drivetrain.setControl(teleopRequest.withVelocityY(trenchAssistVelocity));
+            }
+          } else {
+            drivetrain.setControl(teleopRequest);
+          }
+        } else {
+          drivetrain.setControl(teleopRequest);
+        }
+      }
       case TELEOP_SNAPS -> {
         if (MathUtil.isNear(teleopRequest.RotationalRate, 0, teleopRequest.RotationalDeadband)) {
           drivetrain.setControl(teleopSnapsRequest);
         } else {
           drivetrain.setControl(teleopRequest);
-        }
-      }
-      case TRENCH_ASSIST -> {
-        var robotPose = drivetrain.getState().Pose;
-        var trenchAssistVelocity = getTrenchAssistVelocity(robotPose.getY());
-        if (MathUtil.isNear(teleopRequest.RotationalRate, 0, teleopRequest.RotationalDeadband)) {
-          var snapAngle = Math.round(robotPose.getRotation().getDegrees() / 90.0) * 90.0;
-
-          drivetrain.setControl(
-              teleopSnapsRequest
-                  .withVelocityY(trenchAssistVelocity)
-                  .withTargetDirection(Rotation2d.fromDegrees(snapAngle)));
-        } else {
-          drivetrain.setControl(teleopRequest.withVelocityY(trenchAssistVelocity));
         }
       }
       case TRAILBLAZER ->
@@ -217,8 +225,8 @@ public class Swerve extends StateMachineSubsystem<SwerveState> {
 
   private double getTrenchAssistVelocity(double currentY) {
     return currentY < FieldUtil.FIELD_WIDTH / 2.0
-        ? trenchPidController.calculate(currentY, 0.632968)
-        : trenchPidController.calculate(currentY, 7.436358);
+        ? trenchPidController.calculate(currentY, FieldUtil.BOTTOM_TRENCH_Y)
+        : trenchPidController.calculate(currentY, FieldUtil.TOP_TRENCH_Y);
   }
 
   private boolean ableToTrenchAssist() {
@@ -247,6 +255,7 @@ public class Swerve extends StateMachineSubsystem<SwerveState> {
         < TRENCH_ASSIST_ANGLE_THRESHOLD.get();
   }
 
+  // TODO: Add more logging to debug trench assist
   @Override
   public void whileInState(SwerveState currentState) {
     DogLog.log("Swerve/SnapsNearGoal", snapsNearGoal());

--- a/turret-bot/src/main/java/frc/robot/swerve/SwerveState.java
+++ b/turret-bot/src/main/java/frc/robot/swerve/SwerveState.java
@@ -3,6 +3,5 @@ package frc.robot.swerve;
 public enum SwerveState {
   TELEOP,
   TELEOP_SNAPS,
-  TRENCH_ASSIST,
   TRAILBLAZER;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds field geometry and integrates trench assist into normal teleop, gated by a feature flag.
> 
> - **FieldUtil**: Defines trench constants (`RED_TRENCH_X`, `BLUE_TRENCH_X`, trench length), unsafe trench boxes, and four `TRENCH_ASSIST_ZONES`; adds `getCurrentTrenchAssistZone` and trench Y targets (`BOTTOM_TRENCH_Y`, `TOP_TRENCH_Y`).
> - **FeatureFlags**: Adds `TRENCH_ASSIST` flag.
> - **Swerve**: Enables assist in `TELEOP` when flag is on and `ableToTrenchAssist()` passes (velocity and angle thresholds now default to 4.0 and 40.0). Applies PID-based sideways velocity toward trench target Y and snaps heading to 90° increments when not rotating; replaces hardcoded setpoints with `FieldUtil` constants; removes `TRENCH_ASSIST` state; adds logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5749c41da3a7da3efb185df1c195da4448892b07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->