### PR TITLE
Fix Trailblazer smooth rotation

### DIFF
--- a/shared/src/main/java/com/team581/trailblazer/followers/PidPathFollower.java
+++ b/shared/src/main/java/com/team581/trailblazer/followers/PidPathFollower.java
@@ -8,6 +8,7 @@ import com.team581.trailblazer.ConstraintsCalculator;
 import com.team581.trailblazer.LinearConstraintOptions;
 import com.team581.trailblazer.segments.AutoSegment;
 import dev.doglog.DogLog;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -45,17 +46,24 @@ public class PidPathFollower implements PathFollower {
 
     var distanceToEnd = currentPose.getTranslation().getDistance(targetPose.getTranslation());
 
-    // Find total distance to end of segment
+    // Sum the total linear distance and total angular work remaining through all waypoints in the
+    // segment. These are used together to estimate how long the robot has to complete its rotation,
+    // which drives the dynamic angular velocity cap.
+    var totalAngularWorkRadians =
+        Math.abs(
+            MathUtil.angleModulus(
+                targetPose.getRotation().getRadians() - currentPose.getRotation().getRadians()));
+
+    // Find total distance and angular work to end of segment
     for (int i = currentPointIndex; i < segment.points.size() - 1; i++) {
-      distanceToEnd +=
-          segment
-              .points
-              .get(i)
-              .poseSupplier()
-              .get()
-              .getPose()
-              .getTranslation()
-              .getDistance(segment.points.get(i + 1).getPose().getTranslation());
+      var thisPoint = segment.points.get(i).poseSupplier().get().getPose();
+      var nextPoint = segment.points.get(i + 1).getPose();
+
+      distanceToEnd += thisPoint.getTranslation().getDistance(nextPoint.getTranslation());
+      totalAngularWorkRadians +=
+          Math.abs(
+              MathUtil.angleModulus(
+                  nextPoint.getRotation().getRadians() - thisPoint.getRotation().getRadians()));
     }
 
     // Calculate velocities with PID controller
@@ -70,16 +78,44 @@ public class PidPathFollower implements PathFollower {
     linearVelocity =
         velocityConstrainer.constrainLinearVelocity(
             linearVelocity, currentSpeeds, distanceToEnd, linearConstraints);
+
+    // Compute a dynamic angular velocity cap so that rotation is spread evenly across the
+    // remaining travel time, rather than rotating as fast as possible and then waiting.
+    // estimatedTime = distance / constrained linear velocity gives us roughly how long until we
+    // arrive at the end of the segment. neededAngularVelocity = totalAngularWork / estimatedTime
+    // gives the steady-state omega to finish all remaining rotation right as we arrive.
+    var effectiveAngularConstraints = angularConstraints;
+
+    if (linearVelocity > 1e-3 && distanceToEnd > 1e-3) {
+      var estimatedTime = distanceToEnd / linearVelocity;
+
+      if (estimatedTime > 1e-3 && totalAngularWorkRadians > 1e-6) {
+        var neededAngularVelocity = totalAngularWorkRadians / estimatedTime;
+
+        DogLog.log("Trailblazer/Follower/TotalAngularWorkRadians", totalAngularWorkRadians);
+        DogLog.log("Trailblazer/Follower/DynamicAngularVelocityCap", neededAngularVelocity);
+
+        // Only apply the cap if it is lower than the existing constraint — we don't want to
+        // *increase* the allowed velocity, just potentially reduce it to spread rotation out.
+        if (neededAngularVelocity < angularConstraints.maxVelocity()) {
+          effectiveAngularConstraints =
+              new AngularConstraintOptions(
+                  neededAngularVelocity, angularConstraints.maxAcceleration());
+        }
+      }
+    }
+
     angularVelocity =
         velocityConstrainer.constrainAngularVelocity(
             angularVelocity,
             currentPose.getRotation().getRadians(),
             targetPose.getRotation().getRadians(),
             currentSpeeds,
-            angularConstraints);
+            effectiveAngularConstraints);
 
-    DogLog.log("Trailblazer/Follower/AngularLimit", angularConstraints.maxVelocity());
-    DogLog.log("Trailblazer/Follower/AngularACCLimit", angularConstraints.maxAcceleration());
+    DogLog.log("Trailblazer/Follower/AngularLimit", effectiveAngularConstraints.maxVelocity());
+    DogLog.log(
+        "Trailblazer/Follower/AngularACCLimit", effectiveAngularConstraints.maxAcceleration());
 
     DogLog.log("Trailblazer/Follower/AngularVelocityAfterConstraint", angularVelocity);
 

--- a/shared/src/main/java/com/team581/trailblazer/trackers/HeuristicPathTracker.java
+++ b/shared/src/main/java/com/team581/trailblazer/trackers/HeuristicPathTracker.java
@@ -79,7 +79,6 @@ public class HeuristicPathTracker implements PathTracker {
         t = maxT;
 
         var targetTranslation = targetPose.getTranslation();
-        Rotation2d interpolatedRotation;
 
         if (isArc) {
           var arcMid = currentPoint.arcMidpoint().orElseThrow();
@@ -92,22 +91,12 @@ public class HeuristicPathTracker implements PathTracker {
               p0.times(oneMinusT * oneMinusT)
                   .plus(p1.times(2 * oneMinusT * t))
                   .plus(p2.times(t * t));
-
-          // Two-stage rotation through the arc midpoint rotation to control direction
-          var midRotation = arcMid.getRotation();
-          if (t < 0.5) {
-            // First half: previous waypoint rotation -> mid rotation
-            interpolatedRotation = previousPose.getRotation().interpolate(midRotation, t * 2);
-          } else {
-            // Second half: mid rotation -> target rotation
-            interpolatedRotation = midRotation.interpolate(targetPose.getRotation(), (t - 0.5) * 2);
-          }
-        } else {
-          interpolatedRotation =
-              previousPose.getRotation().interpolate(targetPose.getRotation(), t);
         }
 
-        targetPose = new Pose2d(targetTranslation, interpolatedRotation);
+        // Use the current waypoint's rotation directly — the follower is responsible for
+        // pacing rotation via a dynamic angular velocity cap, rather than the tracker
+        // interpolating an intermediate heading.
+        targetPose = new Pose2d(targetTranslation, targetPose.getRotation());
       }
     }
 


### PR DESCRIPTION
Haven't really tested this at all

The idea is that we stop interpolating rotation on the tracker side. Instead we approximate the angular velocity to hit our goal angle right as we arrive at the goal point. We use that as the maximum angular velocity, and just PID straight to the goal angle.

This fixes the issue of PIDing to little tiny rotation increments with an assumed end velocity of 0, which meant we always lagged behind the goal rotation at that point in the auto.