### PR TITLE
Match timer v2 Sim Verification and Bug fixes

### DIFF
--- a/comp-bot/src/main/java/frc/robot/config/DSOptions.java
+++ b/comp-bot/src/main/java/frc/robot/config/DSOptions.java
@@ -10,6 +10,7 @@ public final class DSOptions {
   public static final BooleanSubscriber USE_CANRANGE = DSOption.of("UseCANRange", true);
   public static final BooleanSubscriber DEFAULT_WON_AUTO = DSOption.of("DefaultWonAuto", true);
   public static final BooleanSubscriber RESET_POSE_FOR_AUTO = DSOption.of("ResetPoseForAuto", true);
+  public static final BooleanSubscriber USE_TELEOP_TIMER = DSOption.of("UseTeleopTimer", true);
 
   public static final BooleanSubscriber PIT_FUNCTIONALITY = DSOption.of("PitFunctionality", false);
 

--- a/comp-bot/src/main/java/frc/robot/hub_activity/HubActivity.java
+++ b/comp-bot/src/main/java/frc/robot/hub_activity/HubActivity.java
@@ -27,6 +27,8 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
   private double scoringShooterTOF = 0.0;
   private boolean tofBasedHubActive = true;
 
+  private boolean hasStartedMatch = false;
+
   private boolean shouldBeastMode = false;
 
   public HubActivity() {
@@ -39,6 +41,7 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
   @Override
   public void autonomousInit() {
     autoTimer.restart();
+    hasStartedMatch = true;
     timeSinceMatchStart = FmsUtil.MATCH_TIME_AT_AUTO_START;
   }
 
@@ -107,12 +110,13 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
 
   @Override
   protected void collectInputs() {
-    if (DriverStation.isAutonomous()) {
+    if (DriverStation.isAutonomous()
+        || DriverStation.isDisabled()
+        || !DSOptions.USE_TELEOP_TIMER.getAsBoolean()) {
       timeSinceMatchStart = autoTimer.get();
-    } else {
+    } else if (DriverStation.isEnabled()) {
       timeSinceMatchStart = teleopTimer.get() + FmsUtil.MATCH_TIME_AT_TELEOP_START;
     }
-    timeSinceMatchStart = teleopTimer.get() + FmsUtil.MATCH_TIME_AT_TELEOP_START;
     timeUntilNextShift =
         FmsUtil.timeUntilNextShift(timeSinceMatchStart, DSOptions.DEFAULT_WON_AUTO.getAsBoolean());
 
@@ -126,7 +130,7 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
 
   @Override
   protected void whileInState(HubActivityState state) {
-    if (DriverStation.isDisabled()) {
+    if (DriverStation.isDisabled() && !hasStartedMatch) {
       teleopTimer.stop();
       teleopTimer.reset();
       autoTimer.stop();

--- a/comp-bot/src/main/java/frc/robot/hub_activity/HubActivity.java
+++ b/comp-bot/src/main/java/frc/robot/hub_activity/HubActivity.java
@@ -19,6 +19,7 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
       DogLog.tunable("HubActivity/FieldHubDelay", 2.0);
 
   private final Timer teleopTimer = new Timer();
+  private final Timer autoTimer = new Timer();
   private double timeSinceMatchStart = 0.0;
 
   private double timeUntilNextShift = 0.0;
@@ -31,7 +32,14 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
   public HubActivity() {
     super(SubsystemPriority.HUB_ACTIVITY, HubActivityState.DEFAULT_STATE);
 
+    autoTimer.start();
     teleopTimer.start();
+  }
+
+  @Override
+  public void autonomousInit() {
+    autoTimer.restart();
+    timeSinceMatchStart = FmsUtil.MATCH_TIME_AT_AUTO_START;
   }
 
   public boolean getActualHubActive() {
@@ -61,7 +69,7 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
 
   @Override
   public void teleopInit() {
-    teleopTimer.reset();
+    teleopTimer.restart();
     timeSinceMatchStart = FmsUtil.MATCH_TIME_AT_TELEOP_START;
   }
 
@@ -99,6 +107,11 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
 
   @Override
   protected void collectInputs() {
+    if (DriverStation.isAutonomous()) {
+      timeSinceMatchStart = autoTimer.get();
+    } else {
+      timeSinceMatchStart = teleopTimer.get() + FmsUtil.MATCH_TIME_AT_TELEOP_START;
+    }
     timeSinceMatchStart = teleopTimer.get() + FmsUtil.MATCH_TIME_AT_TELEOP_START;
     timeUntilNextShift =
         FmsUtil.timeUntilNextShift(timeSinceMatchStart, DSOptions.DEFAULT_WON_AUTO.getAsBoolean());
@@ -113,6 +126,13 @@ public class HubActivity extends StateMachineSubsystem<HubActivityState> {
 
   @Override
   protected void whileInState(HubActivityState state) {
+    if (DriverStation.isDisabled()) {
+      teleopTimer.stop();
+      teleopTimer.reset();
+      autoTimer.stop();
+      autoTimer.reset();
+    }
+
     // Driver station logging
     DogLog.forceNt.log("HubActivity/CurrentShift", FmsUtil.currentShift(timeSinceMatchStart));
     DogLog.forceNt.log("HubActivity/Active", getHubStateColorHex());

--- a/shared/src/main/java/com/team581/util/FmsUtil.java
+++ b/shared/src/main/java/com/team581/util/FmsUtil.java
@@ -20,6 +20,8 @@ public class FmsUtil {
   private static final double SHIFT1_TIME_DURATION = 58.0;
   private static final double TRANSITION_DURATION = 33.0;
 
+  private static final double AUTO_DURATION = 20.0;
+
   public static final double MATCH_TIME_AT_TELEOP_START = 23.0;
   public static final double MATCH_TIME_AT_AUTO_START = 0;
 
@@ -84,10 +86,13 @@ public class FmsUtil {
 
   public static double timeUntilNextShift(
       double timeSinceMatchStart, boolean defaultAutoWinnerValue) {
-    if (DriverStation.isDisabled() || !DriverStation.isTeleop()) {
-      return 0.0;
-    }
 
+    if (timeSinceMatchStart <= AUTO_DURATION) {
+      return AUTO_DURATION - timeSinceMatchStart;
+    }
+    if (timeSinceMatchStart <= MATCH_TIME_AT_TELEOP_START) {
+      return MATCH_TIME_AT_TELEOP_START - timeSinceMatchStart;
+    }
     if (timeSinceMatchStart <= TRANSITION_DURATION) {
       return TRANSITION_DURATION - timeSinceMatchStart;
     }

--- a/shared/src/main/java/com/team581/util/FmsUtil.java
+++ b/shared/src/main/java/com/team581/util/FmsUtil.java
@@ -7,20 +7,21 @@ import java.util.Optional;
 
 public class FmsUtil {
   // Match period shift times in seconds
-  private static final double SHIFT1_TIMESTAMP = 30.0;
-  private static final double SHIFT2_TIMESTAMP = 55.0;
-  private static final double SHIFT3_TIMESTAMP = 80.0;
-  private static final double SHIFT4_TIMESTAMP = 105.0;
-  private static final double ENDGAME_TIMESTAMP = 130.0;
+  private static final double SHIFT1_TIMESTAMP = 33.0;
+  private static final double SHIFT2_TIMESTAMP = 58.0;
+  private static final double SHIFT3_TIMESTAMP = 83.0;
+  private static final double SHIFT4_TIMESTAMP = 108.0;
+  private static final double ENDGAME_TIMESTAMP = 133.0;
 
-  public static final double ENDGAME_DURATION = 160.0;
-  private static final double SHIFT4_TIME_DURATION = 130.0;
-  private static final double SHIFT3_TIME_DURATION = 105.0;
-  private static final double SHIFT2_TIME_DURATION = 80.0;
-  private static final double SHIFT1_TIME_DURATION = 55.0;
-  private static final double TRANSITION_DURATION = 30.0;
+  public static final double ENDGAME_DURATION = 163.0;
+  private static final double SHIFT4_TIME_DURATION = 133.0;
+  private static final double SHIFT3_TIME_DURATION = 108.0;
+  private static final double SHIFT2_TIME_DURATION = 83.0;
+  private static final double SHIFT1_TIME_DURATION = 58.0;
+  private static final double TRANSITION_DURATION = 33.0;
 
-  public static final double MATCH_TIME_AT_TELEOP_START = 20.0;
+  public static final double MATCH_TIME_AT_TELEOP_START = 23.0;
+  public static final double MATCH_TIME_AT_AUTO_START = 0;
 
   public static String currentShift(double timeSinceMatchStart) {
     if (DriverStation.isDisabled() || !DriverStation.isTeleop()) {


### PR DESCRIPTION
So far the timeSinceMatchStart has been set to 0 if disabled. The countdown on driver station was updated to count down 20 seconds in auto and 3 seconds in between auto and teleop. 

Needs to be tested in sim and fix any other bugs.